### PR TITLE
Update deprecated pandas to_csv parameter

### DIFF
--- a/microbiome_helper2/MMSeqs2_functional_annotation/convert_picrust2_to_stratified_output_format.py
+++ b/microbiome_helper2/MMSeqs2_functional_annotation/convert_picrust2_to_stratified_output_format.py
@@ -26,7 +26,7 @@ def main():
     df = df.reindex(columns= cols)
     print (df.head())
     
-    pd.DataFrame.to_csv(df, path_or_buf=outputfileN, sep='\t', na_rep='', header=True, index=False, mode='w', line_terminator='\n', escapechar=None, decimal='.')
+    pd.DataFrame.to_csv(df, path_or_buf=outputfileN, sep='\t', na_rep='', header=True, index=False, mode='w', lineterminator='\n', escapechar=None, decimal='.')
     
 if __name__ == "__main__":
         main();


### PR DESCRIPTION
This updates the deprecated pandas `line_terminator` keyword to `lineterminator` in `convert_picrust2_to_stratified_output_format.py`.

The old keyword was deprecated in pandas 1.5.0 for consistency with `read_csv` and the standard library `csv` module. No behavior change is intended; the line terminator remains `'\n'`.

Tested with:
- `python3 -m py_compile microbiome_helper2/MMSeqs2_functional_annotation/convert_picrust2_to_stratified_output_format.py`
- Ran the script on a minimal TSV input using pandas 3.0.3 and confirmed tab-separated output, expected `function` column output, and `\n` line endings.